### PR TITLE
Simplify credentials configuration

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -147,12 +147,8 @@ This is only configured on the root project.
 [source,groovy]
 ----
 nexusStaging {
-	if (project.hasProperty("sonatypeUsername")) {
-		username = project.sonatypeUsername
-	}
-	if (project.hasProperty("sonatypePassword")) {
-		password = project.sonatypePassword
-	}
+	username = project.findProperty("sonatypeUsername")
+	password = project.findProperty("sonatypePassword")
 	repositoryDescription = "Release ${project.group} ${project.version}"
 }
 ----
@@ -168,12 +164,6 @@ This is applied to every project that is deployed.
 nexusPublishing {
 	repositories {
 		sonatype {
-			if (project.hasProperty("sonatypeUsername")) {
-				username = project.sonatypeUsername
-			}
-			if (project.hasProperty("sonatypePassword")) {
-				password = project.sonatypePassword
-			}
 		}
 	}
 	// these are not strictly required. The default timeouts are set to 1 minute. But Sonatype can be really slow.


### PR DESCRIPTION
`project.findProperty()` returns null if property is not found. `nexus-publishing` can leverage credentials from 'nexus-staging'.

https://github.com/marcphilipp/nexus-publish-plugin#integration-with-the-nexus-staging-plugin